### PR TITLE
Update grpc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "commander": "^2.9.0",
-    "grpc": "^0.12.0",
+    "grpc": "^0.14.0",
     "inquirer": "^1.0.2"
   },
   "bin": {


### PR DESCRIPTION
The new version fixed the issue of modifying method names with CamelCase [https://github.com/grpc/grpc/pull/4709](https://github.com/grpc/grpc/pull/4709), causing it not working with other languages. 

For example, if we define a service in `proto` file:

```
service Foo {
  rpc getBar(BarRequest) returns (BarResponse) {}
}
```

In Java, it's registered with path `/Foo/getBar`, but it's auto modified to `/Foo/GetBar` in `node-grpc` v0.12.0, causing `Method not found` error.
