### PR TITLE
Fixes failing tests and updates nested service handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,6 @@ function createClient(protoFile, directory, serviceName, address, options) {
   };
   let parsed = grpc.load(file);
   let packages = Object.keys(JSON.parse(JSON.stringify(parsed)));
-
   if (packages.length === 1) {
     return init(packages[0], parsed, protoFile, serviceName, address, options);
   } else {
@@ -35,6 +34,24 @@ function createClient(protoFile, directory, serviceName, address, options) {
     }).catch(err => {
         console.error(err);
     });
+  }
+}
+
+// Recursively search a parsed protos definition for the first service
+function findService(def){
+  let keys = Object.keys(def);
+  for(let i=0; i < keys.length; i++){
+    let propName = keys[i]
+    let propValue = def[propName];
+
+    if(typeof propValue === 'object'){
+      let res = findService(propValue);
+      if(res){
+        return res;
+      }
+    }else if(propValue.service){
+      return {name: propName, ctr: propValue};
+    }
   }
 }
 
@@ -54,24 +71,29 @@ function init(packageName, parsed, protoFile, serviceName, address, options) {
     throw new Error(fmt("Unable to find a package in %s", protoFile));
   }
 
-  if (!serviceName) {
-    // Normally you have one service per proto, but not always the case
-    Object.keys(def).forEach(propName => {
-      if (def[propName].service) {
-        serviceName = propName;
-      }
-    });
-  }
-  if (!serviceName || !def[serviceName] || !def[serviceName].service) {
-    throw new Error(fmt('Unable to locate service %s in %s', serviceName, protoFile));
-  }
+  let serviceCtr; //service constructor
 
-  let service = def[serviceName].service;
+  // If a serviceName was provided, select that service from the definitions
+  // TODO: Support recursively searching for service name
+  if (serviceName) {
+    serviceCtr = def[serviceName];
+    if(!serviceCtr || !serviceCtr.service){
+      throw new Error(fmt('Unable to locate service %s in %s', serviceName, protoFile));
+    }
+  }else{
+    // Find the first service and use it
+    let res = findService(def);
+    if(!res){
+      throw new Error(fmt("Unable to locate any service in %s", protoFile));
+    }
+    serviceName = res.name;
+    serviceCtr = res.ctr;
+  }
 
   let creds = createCredentials(options);
-  let client = new def[serviceName](address, creds);
+  let client = new serviceCtr(address, creds);
 
-  printUsage(pkg, serviceName, address, service);
+  printUsage(pkg, serviceName, address, serviceCtr.service);
   console.log("");
 
   let replOpts = {

--- a/test/noservicenested.proto
+++ b/test/noservicenested.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+
+package grpcctest.nest;
+
+message SayRequest {
+  required string sayWhat = 1;
+}
+
+message SayReply {
+  required string saidWhat = 1;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ let grpcc = require('../lib');
 
 describe('grpcc', () => {
   it('should throw to parse non-existant proto file', () => {
-    expect(grpcc.bind(null, '/path/to/nowhere')).to.throw(/read property/);
+    expect(grpcc.bind(null, '/path/to/nowhere', undefined, undefined, ':8080')).to.throw(/read property/);
   });
 
   // TODO: update/remove, temporary won't throw exception as it wait before
@@ -26,6 +26,11 @@ describe('grpcc', () => {
   });
 
   it('should find nested service name', () => {
+    let fn = grpcc.bind(null, './test/noservicenested.proto', undefined, undefined, ':8080');
+    expect(fn).to.throw(/unable to locate/i);
+  });
+
+  it('should throw if no service can be found (nested proto)', () => {
     let fn = grpcc.bind(null, './test/nestedtest.proto', undefined, undefined, ':8080');
     expect(fn).to.not.throw(/unable to locate/i);
   });


### PR DESCRIPTION
This PR fixes the `should throw to parse non-existant proto file` test by adding the missing arguments

This PR also fixes the `should find nested service name` test. This adds a `findService` function that recursively searches the provided definition for a service. This PR also adds a test for nested searching for a service where no service is found.

Although not implemented in this PR, it would not be difficult to extend the `findService` function to search for a particular serviceName as well.