### PR TITLE
Adds grpc to repl context and adds helper function for metadata creation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,9 +80,12 @@ function init(packageName, parsed, protoFile, serviceName, address, options) {
     replMode: repl.REPL_MODE_MAGIC
   };
   let rs = repl.start(replOpts);
+  rs.context.grpc = grpc;
   rs.context.client = client;
   rs.context.printReply = printReply.bind(null, rs);
   rs.context.pr = printReply.bind(null, rs);
+  rs.context.createMetadata = createMetadata;
+  rs.context.cm = createMetadata;
 }
 
 function createCredentials(options) {
@@ -117,6 +120,22 @@ function createCredentials(options) {
   }
 
   return grpc.credentials.createSsl(rootCert, privateKey, certChain);
+}
+
+function createMetadata(metadata) {
+  if (metadata instanceof grpc.Metadata) {
+    return metadata
+  }
+
+  var meta = new grpc.Metadata();
+  for(var k in metadata){
+    var v = metadata[k];
+    if(typeof v !== 'string'){
+      v = v.toString();
+    }
+    meta.add(k, v);
+  }
+  return meta;
 }
 
 function printUsage(pkg, serviceName, address, service) {


### PR DESCRIPTION
This PR adds grpc to the repl context to allow for creating metadata to be passed in requests. This also adds a helper functions, `createMetadata`, for creating metadata from javascript objects as well as an alias of `cm`.