### PR TITLE
Allow connecting to unix sockets by proxying them over TCP

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,12 +4,45 @@ require('colors');
 require('events').prototype.inspect = () => {return 'EventEmitter {}';};
 
 let fs = require('fs');
+let net = require('net');
 let grpc = require('grpc');
 let fmt = require('util').format;
 let repl = require('repl');
 let inquirer = require('inquirer');
 let _eval = require('eval');
 let vm = require('vm');
+
+function createUnixSocketProxy(unixAddr, cb) {
+  let server = net.createServer((conn) => {
+    let unixConn = net.createConnection(unixAddr);
+    unixConn.on('error', () => { conn.end(); });
+    conn.pipe(unixConn);
+    unixConn.pipe(conn);
+
+    conn.unref();
+    unixConn.unref();
+  });
+  server.listen(0, "localhost", () => {
+    server.unref();
+    let port = server.address().port;
+    console.log('Proxying UNIX socket', unixAddr, 'via port', port);
+    cb(null, port);
+  });
+}
+
+function prepareClient(service, args, options) {
+  if (args.address.startsWith('unix:')) {
+    createUnixSocketProxy(args.address.substr(5), (err, tcpPort) => {
+      if (err) return console.error('Unable to prepare proxy:', err);
+
+      args.address = 'localhost:' + tcpPort;
+      init(service, args, options);
+    });
+    return;
+  }
+
+  init(service, args, options);
+}
 
 function createClient(args, options) {
   if (!args.address) {
@@ -46,7 +79,7 @@ function createClient(args, options) {
   if (services.length === 0) {
     console.error('Unable to find any service in proto file');
   } else if (services.length === 1) {
-    return init(services[0], args, options);
+    return prepareClient(services[0], args, options);
   } else {
     inquirer.prompt([{
       type: 'list',
@@ -54,7 +87,8 @@ function createClient(args, options) {
       message: 'What service would you like to connect to?',
       choices: services.map(s => s.fqn),
     }]).then(function(answers) {
-      init(services.find(s => s.fqn === answers.service), args, options);
+      let service = services.find(s => s.fqn === answers.service);
+      prepareClient(service, args, options);
     }).catch(err => {
         console.error(err);
     });


### PR DESCRIPTION
This allows the GRPC client to connect to them. Address should be specified as `unix:[path]`.