### PR TITLE
Fixes enum issue when defined outside a message.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -104,16 +104,16 @@ function foundServiceClient(obj) {
 function findService(def, n){
   let keys = Object.keys(def);
   let found = [];
-  let i = n || 0;
+  let m = n || 0;
 
-  if (i > 5) return [];
+  if (m > 5) return [];
 
   for(let i=0; i < keys.length; i++){
     let propName = keys[i]
     let propValue = def[propName];
 
     if(typeof propValue === 'object'){
-      findService(propValue, i++).forEach(res => {
+      findService(propValue, m++).forEach(res => {
         res.package = `${propName}${res.package ? '.' + res.package : ''}`;
         found.push(res);
       });


### PR DESCRIPTION
This seems to fix an issue where Enumerations that are defined outside of a message body throwing an error. I saw that there was a test that checks it, and it passes. However, when I call the following code from the CLI:

`node bin/grpcc.js -p test/test.proto - a localhost:8080`

I receive the following error:

`Unable to find any service in proto file`

There is currently an open issue(#46) about this.

The issue seems to stem from a shadowed variable, so it's a simple fix. I'd be interested to know why the test passes, but when I try calling it manually it fails. Any ideas?