### PR TITLE
Parse metadata before displaying

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ This is an example of using `grpcc` with the [Skizze](https://github.com/skizzeh
 * In-built, simple to use pretty-printing callbacks:
   * `printReply` to print unary method call replies
   * `streamReply` to print stream `call.on('data'...` replies
+  * `printMetadata` to parse and print metadata using `call.on('metadata', pm)`
 * Support for adding gRPC metadata via `createMetadata`
+* Parsing of error-metadata to json
 * Full support for streams (client, server, and bi-directional)
 * Flexibilty of a full nodejs environment that can be as simple or complex as required
 * **eval** support allows using grpcc like curl, fire off a request and have JSON printed to the console
@@ -44,6 +46,7 @@ Once `grpcc` has connected, it will print out usage instructions for the configu
 * `printReply` - a convenience callback for printing the response of an RPC call (nicer than `console.log`) (alias: `pr`)
 * `streamReply` - a convenience callback for printing the response of an stream's `'data'` event (nicer than `console.log`) (alias: `cr`)
 * `createMetadata` - a convenience function for converting plain javascript objects to gRPC metadata (alias: `cm`)
+* `printMetadata` - a convenience callback for printing the metadata of an RPC call (nicer than `console.log`) (alias: `pm`)
 
 
 The REPL environment uses node's [`repl`](https://nodejs.org/api/repl.html) module, so feel free to use any of the in-built features such as save/restore history etc.

--- a/examples/unary.js
+++ b/examples/unary.js
@@ -1,3 +1,3 @@
 let metadata = createMetadata({ this: 'is', my: 'metadata' });
 client.sayHello({ sayWhat: 'hello' }, metadata, pr)
-  .on('metadata', streamReply);
+  .on('metadata', pm);

--- a/lib/index.js
+++ b/lib/index.js
@@ -140,6 +140,8 @@ function init(service, args, options) {
     table.sr = table.streamReply;
     table.createMetadata = createMetadata;
     table.cm = createMetadata;
+    table.printMetadata = printMetadata.bind(null, displayPrompt, newLine);
+    table.pm = table.printMetadata;
   }
 
   if (ev && ev.length > 0) {
@@ -248,6 +250,7 @@ function printUsage(pkg, serviceName, address, service) {
   printCmd('printReply', 'function to easily print a unary call reply', 'pr');
   printCmd('streamReply', 'function to easily print stream call replies', 'sr');
   printCmd('createMetadata', 'convert JS objects into grpc metadata instances', 'cm');
+  printCmd('printMetadata', "function to easily print a unary call's metadata", 'pm');
 }
 
 function getPrompt(serviceName, address) {
@@ -257,11 +260,24 @@ function getPrompt(serviceName, address) {
 function printReply(displayPrompt, newLine, err, reply) {
   newLine();
   if (err) {
+    if (err.metadata) {
+      err.metadata = err.metadata.getMap();
+    }
+
     console.log("Error: ".red, err);
   } else {
     console.log(JSON.stringify(reply, false, '  '));
     displayPrompt();
   }
+}
+
+function printMetadata(displayPrompt, newLine, metadata) {
+  newLine();
+  let obj = {
+    Metadata: metadata.getMap()
+  }
+  console.log(JSON.stringify(obj, false, '  '));
+  displayPrompt();
 }
 
 function streamReply(displayPrompt, newLine, reply) {


### PR DESCRIPTION
Previously, we saw metadata in errors, or using `.on('metadata', pr)`,
that was unparsed and thus lossy:
`Metadata { _internal_repr: { 'x-error-id': [Array] } }`

Now, we use `getMap()` to turn it back into a json object:
`{ 'x-error-id': '0x1f020220' }`

Fixes #50